### PR TITLE
Increase send loop iterations

### DIFF
--- a/TcpClient/Program.cs
+++ b/TcpClient/Program.cs
@@ -20,7 +20,7 @@ class TcpClientApp
 
             var receiveBuffer = new byte[512];
             int totalReceived = 0;
-            while (totalReceived < 512 * 1000)
+            while (totalReceived < 512 * 100000)
             {
                 int bytesRead = await stream.ReadAsync(receiveBuffer, 0, receiveBuffer.Length);
                 if (bytesRead == 0)

--- a/TcpClientRust/src/main.rs
+++ b/TcpClientRust/src/main.rs
@@ -14,7 +14,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     let mut receive_buffer = [0u8; 512];
     let mut total_received = 0;
-    while total_received < 512 * 1000 {
+    while total_received < 512 * 100000 {
         let bytes_read = stream.read(&mut receive_buffer)?;
         if bytes_read == 0 {
             return Ok(());

--- a/TcpServer/Program.cs
+++ b/TcpServer/Program.cs
@@ -34,7 +34,7 @@ class TcpServer
         try
         {
             var sw = Stopwatch.StartNew();
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < 100000; i++)
             {
                 await stream.WriteAsync(SendBuffer, 0, SendBuffer.Length);
             }

--- a/TcpServerNative/server.c
+++ b/TcpServerNative/server.c
@@ -12,7 +12,7 @@
 
 #define PORT 5000
 #define BUFFER_SIZE 512
-#define SEND_COUNT 1000
+#define SEND_COUNT 100000
 
 static void fill_random(unsigned char* buf, size_t len)
 {


### PR DESCRIPTION
## Summary
- send 100,000 messages in the C#, Rust and C servers/clients

## Testing
- `cargo build --release --manifest-path TcpClientRust/Cargo.toml`
- `cmake -S TcpServerNative -B build && cmake --build build`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684412a1c6c4832f8382e80216c9012d